### PR TITLE
Visualization: Update Ruby 3.3.0

### DIFF
--- a/visualization/Dockerfile
+++ b/visualization/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM ruby:3.2.2-alpine as builder
+FROM ruby:3.3.0-alpine as builder
 LABEL maintainer "mi2428 <tmiya@protonmail.ch>"
 
 ARG BUILDTIME_RAILS_SECRETKEY_FILE
@@ -43,7 +43,7 @@ RUN --mount=type=secret,id=rails_secret_key_base,target=/run/secrets/rails_secre
     --mount=type=secret,id=db_password,target=/run/secrets/db_password
 RUN SECRET_KEY_BASE=DUMMY bundle exec rails assets:precompile
 
-FROM ruby:3.2.2-alpine as production
+FROM ruby:3.3.0-alpine as production
 LABEL maintainer "mi2428 <tmiya@protonmail.ch>"
 LABEL org.opencontainers.image.source https://github.com/SINDAN/sindan-docker
 


### PR DESCRIPTION
## Summary
Visualization: Update Ruby 3.3.0

## Changes
- Visualization
  - ruby 3.2.2 -> 3.3.0

## Related URL
- Ruby 3.3.0 Released
  - https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
