### PR TITLE
Fix build error of fluentd

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -10,6 +10,7 @@ USER root
 RUN apk add --no-cache --update mariadb-connector-c \
  && apk add --no-cache --update --virtual .build-deps \
       build-base ruby-dev mariadb-dev mariadb-connector-c \
+ && gem install multi_json -v 1.15.0 \
  && gem install fluent-plugin-http-heartbeat \
  && gem install fluent-plugin-mysql \
  && gem sources --clear-all \


### PR DESCRIPTION
This Pull Request fixs a build error in fluentd.

https://github.com/SINDAN/sindan-docker/actions/runs/16822130059/job/47651074254

It adds the multi_json gem dependency to the fluentd container to address an error caused by the combination of the Ruby version and the multi_json gem version.

https://github.com/sferik/multi_json/blob/main/CHANGELOG.md#1150
