### PR TITLE
Fix TLS verification error caused by mariadb-connector-c v3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       DB_HOST: mysql
       DB_PASSWORD_FILE: "/run/secrets/db_password"
       ACCOUNTS_FILE: "/run/secrets/accounts"
+      MARIADB_TLS_DISABLE_PEER_VERIFICATION: "1"
     command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     healthcheck:
       <<: *default-healthcheck


### PR DESCRIPTION
### Summary
Fixes the following error that occurs during `rails db:migrate` (`make init`):
> ActiveRecord::ConnectionNotEstablished: TLS/SSL error: self-signed certificate in certificate chain (ActiveRecord::ConnectionNotEstablished)

### Changes
- visualization service: Add environment variable `MARIADB_TLS_DISABLE_PEER_VERIFICATION = 1`

### Steps to reproduce
When running `rails db:migrate` as part of `make init`, the following error occurs:
```
$ make pull init
...
docker compose up -d mysql
[+] up 1/1
 ✔ Container sindan-docker-mysql-1 Recreated                                                                                                                                                          1.0s
docker compose run --rm visualization bundle exec rails db:migrate
[+]  1/1t 1/11
 ✔ Container sindan-docker-mysql-1 Running                                                                                                                                                            0.0s
Container sindan-docker-mysql-1 Waiting 
Container sindan-docker-mysql-1 Healthy 
Container sindan-docker-visualization-run-b0ea8bcc2577 Creating 
Container sindan-docker-visualization-run-b0ea8bcc2577 Created 
bin/rails aborted!
ActiveRecord::ConnectionNotEstablished: TLS/SSL error: self-signed certificate in certificate chain (ActiveRecord::ConnectionNotEstablished)
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.1.2/lib/active_record/connection_adapters/mysql2_adapter.rb:36:in 'ActiveRecord::ConnectionAdapters::Mysql2Adapter.new_client'
...
```

### Root Cause
Starting from `mariadb-connector-c` v3.4, `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` is enabled by default.
https://mariadb.com/docs/release-notes/connectors/c/3.4/3.4.3

### Related Issue
- https://github.com/brianmario/mysql2/issues/1379
